### PR TITLE
Added support for Siglent SPD1000X series power supplies

### DIFF
--- a/extensions-list.txt
+++ b/extensions-list.txt
@@ -96,3 +96,5 @@ https://github.com/eez-open/modular-psu-firmware/raw/master/build/extensions/eez
 # Sigilent (initial versions)
 ./org/siglent/ssa3000x/siglent_ssa3031x-0.1.0.zip
 ./org/siglent/ssa3000x/siglent_ssa3032x-0.1.0.zip
+https://github.com/lexbrugman/my-eez-studio-extensions/raw/master/siglent-spd1000x/siglent_spd1168x-1.zip
+https://github.com/lexbrugman/my-eez-studio-extensions/raw/master/siglent-spd1000x/siglent_spd1305x-1.zip


### PR DESCRIPTION
This change adds remote control support for:
 - Siglent SPD1305X
 - Siglent SPD1168X